### PR TITLE
Fix for moveItem, it now correctly places the fromPosition item to th…

### DIFF
--- a/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
+++ b/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
@@ -306,7 +306,17 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
                  @IntRange(from = 0, to = Integer.MAX_VALUE.toLong()) toPosition: Int,
                  notifyAdapter: Boolean = true) {
 
-        Collections.swap(recyclerItems, fromPosition, toPosition)
+        val size = recyclerItems.size
+
+        if (fromPosition in 0..size && toPosition in 0..size) {
+            val swapTmp = recyclerItems[fromPosition]
+            recyclerItems.removeAt(fromPosition)
+            recyclerItems.add(toPosition, swapTmp)
+        } else {
+            val error = "Moving item from $fromPosition to $toPosition failed! Items count was $size"
+            Log.e(TAG, error)
+        }
+
 
         if (notifyAdapter) {
             notifyItemMoved(fromPosition, toPosition)

--- a/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
+++ b/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
@@ -309,8 +309,7 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
         val size = recyclerItems.size
 
         if (fromPosition in 0 until size && toPosition in 0 until size) {
-            val swapTmp = recyclerItems[fromPosition]
-            recyclerItems.removeAt(fromPosition)
+            val swapTmp = recyclerItems.removeAt(fromPosition)
             recyclerItems.add(toPosition, swapTmp)
         } else {
             val error = "Moving item from $fromPosition to $toPosition failed! Items count was $size"

--- a/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
+++ b/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
@@ -308,7 +308,7 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
 
         val size = recyclerItems.size
 
-        if (fromPosition in 0..size && toPosition in 0..size) {
+        if (fromPosition in 0 until size && toPosition in 0 until size) {
             val swapTmp = recyclerItems[fromPosition]
             recyclerItems.removeAt(fromPosition)
             recyclerItems.add(toPosition, swapTmp)

--- a/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
+++ b/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
@@ -309,13 +309,12 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
         val size = recyclerItems.size
 
         if (fromPosition in 0 until size && toPosition in 0 until size) {
-            val swapTmp = recyclerItems.removeAt(fromPosition)
-            recyclerItems.add(toPosition, swapTmp)
+            val itemToMove = recyclerItems.removeAt(fromPosition)
+            recyclerItems.add(toPosition, itemToMove)
         } else {
             val error = "Moving item from $fromPosition to $toPosition failed! Items count was $size"
             Log.e(TAG, error)
         }
-
 
         if (notifyAdapter) {
             notifyItemMoved(fromPosition, toPosition)


### PR DESCRIPTION
RecyclerView adapter `notifyItemMoved` uses a move from->to position logic which removes the item from position `from` and inserts it at position `to`, and then moves the items above/below the `to` position