### PR TITLE
Add support for long click propagation of an item

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ if (adapter.getItemViewType(4) == SimpleTextRecyclerItem.TYPE) {
 ````
 - Handle `itemView` events
 ```java
-adapter.setOnItemClickListener(new DiverseRecyclerAdapter.OnItemClickListener() {
+adapter.setOnItemActionListener(new DiverseRecyclerAdapter.OnItemActionListener() {
     @Override
     public void onItemClicked(@NotNull View v, int position) {
         // Handle itemView click

--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ adapter.setOnItemClickListener(new DiverseRecyclerAdapter.OnItemClickListener() 
     public void onItemClicked(@NotNull View v, int position) {
         // Handle itemView click
     }
+    
+    @Override
+    public boolean onItemLongClicked(@NotNull View v, int position) {
+        // Handle itemView long click 
+        return super.onItemLongClicked();
+    }
+    
     @Override
     public boolean onItemTouched(@NotNull View v, @NotNull MotionEvent event, int position) {
         // Handle itemView touch events

--- a/demo/src/main/java/com/trading212/demo/samples/HeterogeneousListActivity.kt
+++ b/demo/src/main/java/com/trading212/demo/samples/HeterogeneousListActivity.kt
@@ -42,6 +42,21 @@ class HeterogeneousListActivity : BaseActivity() {
 
                 Toast.makeText(v.context, text, Toast.LENGTH_SHORT).show()
             }
+
+            override fun onItemLongClicked(v: View, position: Int): Boolean {
+
+                val text = when (adapter.getItemViewType(position)) {
+
+                    SimpleImageRecyclerItem.TYPE -> "Long clicked image at position $position"
+                    SimpleTextRecyclerItem.TYPE -> "Long clicked ${adapter.getItem<SimpleTextRecyclerItem>(position).data}"
+                    ImageTextRecyclerItem.TYPE -> "Long clicked  image ${adapter.getItem<ImageTextRecyclerItem>(position).data?.name}"
+                    else -> "Unknown item long clicked"
+                }
+
+                Toast.makeText(v.context, text, Toast.LENGTH_SHORT).show()
+
+                return true
+            }
         }
     }
 }

--- a/demo/src/main/java/com/trading212/demo/samples/HeterogeneousListActivity.kt
+++ b/demo/src/main/java/com/trading212/demo/samples/HeterogeneousListActivity.kt
@@ -28,7 +28,7 @@ class HeterogeneousListActivity : BaseActivity() {
 
         adapter.addItems(items)
 
-        adapter.onItemClickListener = object : DiverseRecyclerAdapter.OnItemClickListener() {
+        adapter.onItemActionListener = object : DiverseRecyclerAdapter.OnItemActionListener() {
 
             override fun onItemClicked(v: View, position: Int) {
 

--- a/demo/src/main/java/com/trading212/demo/samples/HomogeneousListActivity.java
+++ b/demo/src/main/java/com/trading212/demo/samples/HomogeneousListActivity.java
@@ -21,7 +21,7 @@ public class HomogeneousListActivity extends BaseActivity {
         }
         adapter.notifyDataSetChanged();
 
-        adapter.setOnItemClickListener(new DiverseRecyclerAdapter.OnItemClickListener() {
+        adapter.setOnItemActionListener(new DiverseRecyclerAdapter.OnItemActionListener() {
 
             @Override
             public void onItemClicked(@NotNull View v, int position) {

--- a/demo/src/main/java/com/trading212/demo/samples/HomogeneousListActivity.java
+++ b/demo/src/main/java/com/trading212/demo/samples/HomogeneousListActivity.java
@@ -29,6 +29,14 @@ public class HomogeneousListActivity extends BaseActivity {
                 SimpleTextRecyclerItem item = adapter.getItem(position);
                 Toast.makeText(v.getContext(), "Clicked " + item.getData(), Toast.LENGTH_SHORT).show();
             }
+
+            @Override
+            public boolean onItemLongClicked(@NotNull View v, int position) {
+                SimpleTextRecyclerItem item = adapter.getItem(position);
+                Toast.makeText(v.getContext(), "Long clicked " + item.getData(), Toast.LENGTH_SHORT).show();
+
+                return true;
+            }
         });
     }
 }

--- a/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
+++ b/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
@@ -68,13 +68,13 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
 
     override fun getItemId(position: Int): Long = getItem<RecyclerItem<*, *>>(position).id
 
-    override fun onAttachedToRecyclerView(recyclerView: RecyclerView?) {
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
         super.onAttachedToRecyclerView(recyclerView)
 
         this.recyclerView = recyclerView
     }
 
-    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView?) {
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
 
         this.recyclerView = null
 
@@ -115,6 +115,10 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
             holder.itemView.setOnTouchListener { v, event ->
                 listener.onItemTouched(v, event, holder.adapterPosition)
             }
+        }
+
+        holder.itemView.setOnLongClickListener { v ->
+            onItemClickListener?.onItemLongClicked(v, holder.adapterPosition) ?: false
         }
 
         holder.itemView.setOnClickListener { v ->
@@ -689,7 +693,7 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
          * @return the [View] for the given resource id. Tries to cast it to the inferred type
          */
         @CheckResult
-        protected fun <V : View> findViewById(@IdRes id: Int): V? = itemView.findViewById(id) as V?
+        protected fun <V : View> findViewById(@IdRes id: Int): V? = itemView.findViewById(id)
 
         /**
          * In order to support selection mode, the selectable [RecyclerItem]'s [ViewHolder] should implement this interface.
@@ -714,6 +718,14 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
          * @param position The position of the touched [RecyclerItem] in the adapter
          */
         abstract fun onItemClicked(v: View, position: Int)
+
+        /**
+         * Called on itemView long click event
+         *
+         * @param v The itemView of the [RecyclerItem]'s [ViewHolder]
+         * @param position The position of the touched [RecyclerItem] in the adapter
+         */
+        open fun onItemLongClicked(v: View, position: Int): Boolean = false
 
         /**
          * Called on item touch event

--- a/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
+++ b/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
@@ -36,7 +36,7 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
     }
 
     /**
-     * @property onItemActionListener Listener to receive item click events
+     * @property onItemActionListener Listener to receive item action events
      */
     var onItemActionListener: OnItemActionListener? = null
 
@@ -715,7 +715,7 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
     abstract class OnItemActionListener {
 
         /**
-         * Called on itemView click event
+         * Called on item click event
          *
          * @param v The itemView of the [RecyclerItem]'s [ViewHolder]
          * @param position The position of the touched [RecyclerItem] in the adapter
@@ -723,7 +723,7 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
         abstract fun onItemClicked(v: View, position: Int)
 
         /**
-         * Called on itemView long click event
+         * Called on item long click event
          *
          * @param v The itemView of the [RecyclerItem]'s [ViewHolder]
          * @param position The position of the long clicked [RecyclerItem] in the adapter
@@ -731,7 +731,7 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
         open fun onItemLongClicked(v: View, position: Int): Boolean = false
 
         /**
-         * Called on itemView touch event
+         * Called on item touch event
          *
          * @param v The itemView of the [RecyclerItem]'s [ViewHolder]
          * @param event The [MotionEvent] on the itemView

--- a/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
+++ b/diverse-recycler-adapter/src/main/java/com/trading212/diverserecycleradapter/DiverseRecyclerAdapter.kt
@@ -36,9 +36,9 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
     }
 
     /**
-     * @property onItemClickListener Listener to receive item click events
+     * @property onItemActionListener Listener to receive item click events
      */
-    var onItemClickListener: OnItemClickListener? = null
+    var onItemActionListener: OnItemActionListener? = null
 
     /**
      * @property onItemSelectionStateChangeListener Listener to receive item selection state change events
@@ -111,21 +111,24 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
             }
         }
 
-        onItemClickListener?.let { listener ->
-            holder.itemView.setOnTouchListener { v, event ->
-                listener.onItemTouched(v, event, holder.adapterPosition)
-            }
-        }
+        onItemActionListener?.let { listener ->
+            holder.itemView.apply {
 
-        holder.itemView.setOnLongClickListener { v ->
-            onItemClickListener?.onItemLongClicked(v, holder.adapterPosition) ?: false
+                setOnTouchListener { v, event ->
+                    listener.onItemTouched(v, event, holder.adapterPosition)
+                }
+
+                setOnLongClickListener { v ->
+                    listener.onItemLongClicked(v, holder.adapterPosition)
+                }
+            }
         }
 
         holder.itemView.setOnClickListener { v ->
 
             holder.onItemViewClickedInternal()
 
-            onItemClickListener?.onItemClicked(v, holder.adapterPosition)
+            onItemActionListener?.onItemClicked(v, holder.adapterPosition)
 
             if (selectionMode != null && holder is ViewHolder.Selectable) {
 
@@ -709,7 +712,7 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
         }
     }
 
-    abstract class OnItemClickListener {
+    abstract class OnItemActionListener {
 
         /**
          * Called on itemView click event
@@ -723,12 +726,12 @@ class DiverseRecyclerAdapter : RecyclerView.Adapter<DiverseRecyclerAdapter.ViewH
          * Called on itemView long click event
          *
          * @param v The itemView of the [RecyclerItem]'s [ViewHolder]
-         * @param position The position of the touched [RecyclerItem] in the adapter
+         * @param position The position of the long clicked [RecyclerItem] in the adapter
          */
         open fun onItemLongClicked(v: View, position: Int): Boolean = false
 
         /**
-         * Called on item touch event
+         * Called on itemView touch event
          *
          * @param v The itemView of the [RecyclerItem]'s [ViewHolder]
          * @param event The [MotionEvent] on the itemView

--- a/gradle/versionConfig.gradle
+++ b/gradle/versionConfig.gradle
@@ -1,7 +1,7 @@
 ext {
     libraryVersion = '0.9.5'
 
-    android_support_version = '27.+'
+    android_support_version = '27.1.0'
 
     compile_sdk_version = 27
     min_sdk_version = 15


### PR DESCRIPTION
Fixed changes to the RecyclerView.Adapter API (They have added `NonNull` annotation making the Kotlin code without the nullable indicator.

Remove unneeded explicit cast of `View`.